### PR TITLE
Feature: Android Inset 및 키보드 처리 개선 (API 36 대응)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/core/design-system/src/main/java/com/lafi/lawyer/core/design_system/activity/BaseActivity.kt
+++ b/core/design-system/src/main/java/com/lafi/lawyer/core/design_system/activity/BaseActivity.kt
@@ -31,20 +31,25 @@ abstract class BaseActivity<T: ViewBinding>(
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        // 초기에 시스템 바 패딩만 적용
+        // WindowInsets 리스너와 애니메이션 콜백을 함께 설정
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
+            // 초기 시스템 바 인셋만 적용 (키보드는 애니메이션 콜백에서 처리)
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            // 한번 적용 후 리스너 제거 (선택적)
-            ViewCompat.setOnApplyWindowInsetsListener(binding.root, null)
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+
+            // 둘 중 더 큰 값으로 bottom 패딩 설정
+            val bottom = maxOf(systemBars.bottom, ime.bottom)
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, bottom)
+
+            // WindowInsets를 소비하지 않고 반환하여 하위 뷰에서도 처리 가능하도록 함
             insets
         }
 
         ViewCompat.setWindowInsetsAnimationCallback(binding.root, object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
-            // 애니메이션 시작 시 호출
-            override fun onPrepare(animation: WindowInsetsAnimationCompat) {}
+            override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                super.onPrepare(animation)
+            }
 
-            // 애니메이션 진행 중 호출
             override fun onProgress(
                 insets: WindowInsetsCompat,
                 runningAnimations: List<WindowInsetsAnimationCompat>
@@ -59,6 +64,10 @@ abstract class BaseActivity<T: ViewBinding>(
                 // 콘텐츠 뷰의 패딩 업데이트
                 binding.root.setPadding(systemBars.left, systemBars.top, systemBars.right, bottom)
                 return insets
+            }
+
+            override fun onEnd(animation: WindowInsetsAnimationCompat) {
+                super.onEnd(animation)
             }
         })
     }

--- a/core/design-system/src/main/java/com/lafi/lawyer/core/design_system/fragment/BaseBottomSheetFragment.kt
+++ b/core/design-system/src/main/java/com/lafi/lawyer/core/design_system/fragment/BaseBottomSheetFragment.kt
@@ -5,7 +5,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.viewbinding.ViewBinding
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 abstract class BaseBottomSheetFragment<T : ViewBinding>(
@@ -27,9 +32,50 @@ abstract class BaseBottomSheetFragment<T : ViewBinding>(
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return super.onCreateDialog(savedInstanceState).apply {
-            // Dialog가 취소되지 않도록 설정 (선택적)
-            // setCanceledOnTouchOutside(false)
-            // setCancelable(false)
+            // BottomSheet가 키보드에 의해 밀려나도록 설정
+            window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+
+            // BottomSheet Dialog인 경우 추가 설정
+            if (this is BottomSheetDialog) {
+                setOnShowListener {
+                    // BottomSheet의 루트 뷰에 WindowInsets 리스너 설정
+                    val bottomSheet = findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+                    bottomSheet?.let { sheet ->
+                        ViewCompat.setOnApplyWindowInsetsListener(sheet) { view, insets ->
+                            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+                            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+                            // IME가 표시될 때 bottom padding 적용
+                            view.setPadding(
+                                view.paddingLeft,
+                                view.paddingTop,
+                                view.paddingRight,
+                                maxOf(ime.bottom, systemBars.bottom)
+                            )
+                            insets
+                        }
+
+                        // 키보드 애니메이션 처리
+                        ViewCompat.setWindowInsetsAnimationCallback(sheet, object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+                            override fun onProgress(
+                                insets: WindowInsetsCompat,
+                                runningAnimations: List<WindowInsetsAnimationCompat>
+                            ): WindowInsetsCompat {
+                                val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+                                val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+                                sheet.setPadding(
+                                    sheet.paddingLeft,
+                                    sheet.paddingTop,
+                                    sheet.paddingRight,
+                                    maxOf(ime.bottom, systemBars.bottom)
+                                )
+                                return insets
+                            }
+                        })
+                    }
+                }
+            }
         }
     }
 

--- a/core/util/src/main/java/com/lafi/lawyer/core/util/keyboard_ovserver/impl/KeyboardObserverApi30.kt
+++ b/core/util/src/main/java/com/lafi/lawyer/core/util/keyboard_ovserver/impl/KeyboardObserverApi30.kt
@@ -15,7 +15,8 @@ internal class KeyboardObserverApi30(
     private var singleEventListener: KeyboardVisibilityListener? = null
 
     // 마지막에 완전 노출되었던 키보드 높이 (사라질 때 기준값으로 사용)
-    private var previousFinalKeyboardHeight: Int = 1028
+    // 초기값을 0으로 설정하고 첫 키보드 표시 시 실제 높이로 업데이트
+    private var previousFinalKeyboardHeight: Int = 0
 
     init {
         registerWindowInsetsAnimationCallback()
@@ -46,17 +47,22 @@ internal class KeyboardObserverApi30(
                 // 현재 키보드 높이 (IME 영역)
                 val currentKeyboardHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
 
+                // 키보드가 표시되는 중이고 이전 높이가 0이면 현재 높이를 기준으로 설정
+                if (currentKeyboardHeight > 0 && previousFinalKeyboardHeight == 0) {
+                    previousFinalKeyboardHeight = currentKeyboardHeight
+                }
+
                 // 현재 애니메이션의 목표 높이를 기준으로 진행률 계산
                 val normalizedPercent = if (previousFinalKeyboardHeight > 0) {
                     currentKeyboardHeight.toFloat() / previousFinalKeyboardHeight.toFloat()
                 } else {
-                    0f
+                    if (currentKeyboardHeight > 0) 1f else 0f
                 }
 
                 // 일반 리스너 호출
                 listener?.onKeyboardVisibilityChanged(
                     currentKeyboardHeight > 0,
-                    previousFinalKeyboardHeight,
+                    maxOf(previousFinalKeyboardHeight, currentKeyboardHeight),
                     normalizedPercent.coerceIn(0f, 1f)
                 )
 

--- a/feature/login/src/main/AndroidManifest.xml
+++ b/feature/login/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application>
         <activity
             android:name="com.lafi.lawyer.feature.login.LoginActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
 
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"

--- a/feature/signup/src/main/AndroidManifest.xml
+++ b/feature/signup/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application>
         <activity
             android:name=".SignupActivity"
-            android:exported="false"/>
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Android 15+ (API 35/36) edge-to-edge 환경에서 키보드와 시스템 인셋을 올바르게 처리하도록 개선

## 주요 변경사항

### 1. AndroidManifest 설정 추가
- MainActivity, LoginActivity, SignupActivity에 windowSoftInputMode="adjustResize" 추가
- API 35+ edge-to-edge 환경에서 시스템에 키보드 처리 의도 전달

### 2. BaseActivity WindowInsets 처리 개선
- WindowInsets 리스너 조기 제거 문제 해결
- IME와 시스템 바 인셋을 모두 처리하도록 개선
- WindowInsetsAnimationCallback과의 충돌 방지
- 하위 뷰에서도 인셋 처리 가능하도록 인셋 전달

### 3. BaseBottomSheetFragment 인셋 처리 추가
- BottomSheet Dialog에 키보드 인셋 처리 로직 추가
- WindowInsets 리스너 및 애니메이션 콜백 구현
- 입력 필드가 있는 BottomSheet에서 키보드가 컨텐츠를 가리지 않도록 개선

### 4. KeyboardObserver 개선
- 하드코딩된 키보드 높이(1028) 제거
- 초기값 0으로 설정 후 첫 키보드 표시 시 실제 높이로 동적 업데이트
- 다양한 디바이스 및 키보드 크기 대응

## 기대 효과
- ✅ 키보드가 입력 필드를 가리지 않음
- ✅ 부드러운 키보드 애니메이션
- ✅ BottomSheet에서 키보드 처리 개선
- ✅ Android 15+ edge-to-edge 완벽 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)